### PR TITLE
`writeTableCF` now removes quartet sets that were not observed in tree sample

### DIFF
--- a/src/readquartetdata.jl
+++ b/src/readquartetdata.jl
@@ -88,6 +88,8 @@ function writeTableCF(quartets::Vector{QuartetT{T}},
     for q in quartets
       push!(df, (q.number, taxstring.(q.taxonnumber)..., q.data...) )
     end
+    # return only the quartet sets that were observed in at least one tree 
+    df = df[df.ngenes .!= 0.0, :]
     return df
 end
 


### PR DESCRIPTION
For some quartet sets we can have combinations that are not observed in the tree sample because all possible combinations are generated that may not be filled. This however represents lack of data in the sense that a given entry with 0.0 in all qs, and then also in ngenes, adds no information.