### PR TITLE
Fixed bug when numTrees is not set in DataCF

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SNaQ"
 uuid = "c2bf7a07-44d2-4d11-b5e2-76dc5aa199d6"
 authors = ["Claudia Solis-Lemus <crsl4@users.noreply.github.com>", "Paul Bastide <pbastide@users.noreply.github.com>", "Cecile Ane <cecileane@users.noreply.github.com>", "and contributors"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/readquartetdata.jl
+++ b/src/readquartetdata.jl
@@ -167,7 +167,7 @@ function readtableCF!(df::DataFrames.DataFrame, co::Vector{Int}; mergerows=false
     end
     d = DataCF(quartets)
     if "ngenes" in names(df)
-        d.numTrees = Int64(minimum(df.ngenes))
+        d.numTrees = Int(minimum(df.ngenes))
     end
     if(!isempty(repSpecies))
         d.repSpecies = repSpecies

--- a/src/readquartetdata.jl
+++ b/src/readquartetdata.jl
@@ -166,6 +166,9 @@ function readtableCF!(df::DataFrames.DataFrame, co::Vector{Int}; mergerows=false
         end
     end
     d = DataCF(quartets)
+    if "ngenes" in names(df)
+        d.numTrees = Int64(minimum(df.ngenes))
+    end
     if(!isempty(repSpecies))
         d.repSpecies = repSpecies
     end

--- a/src/snaq_optimization.jl
+++ b/src/snaq_optimization.jl
@@ -1155,7 +1155,7 @@ function proposedTop!(move::Integer, newT::HybridNetwork,random::Bool, count::In
     N::Integer, movescount::Vector{Int}, movesfail::Vector{Int}, multall::Bool, probQR::Float64, d::DataCF)
     global CHECKNET
     1 <= move <= 6 || error("invalid move $(move)") #fixit: if previous move rejected, do not redo it!
-    probQR == 0.0 || d.numTrees != -1 || error("If probQR is not 0.0, d must not be an empty DataCF")
+    probQR == 0.0 || d.numQuartets > 0 || error("If probQR is not 0.0, d must not be an empty DataCF")
     @debug "current move: $(int2move[move])"
     if(move == 1)
         success = addHybridizationUpdateSmart!(newT, N, probQR, d)


### PR DESCRIPTION
The `numTrees` parameter of a DataCF was previously not set in the `readtableCF` function no matter what. This led to a bug where, if `probQR > 0.0`, SNaQ would think that the DataCF was empty because `numTrees` was the default value of -1, when in fact the DataCF had many data entries. Here, there are two updates:
1. The `numTrees` field is set when the `ngenes` column is present in the DataFrame that the CFs are read from in `readtableCF`
2. The check for `probQR` checks the `numQuartets` field now instead of `numTrees`, because `numQuartets` should always be accurate, whereas `numTrees` may still be the default -1 in a DataCF.