### PR TITLE
fix #17: identification of edges in a bad diamond I

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To get help, check
 - the latest [PhyloNetworks documentation](https://juliaphylo.github.io/PhyloNetworks.jl/dev)
 - a [wiki](https://github.com/juliaphylo/PhyloNetworks.jl/wiki) for a
   step-by-step tutorial with background on networks (last revised 2022)
-- [tutorial](https://cecileane.github.io/networkPCM-workshop/) for
+- [tutorial](https://juliaphylo.github.io/networkPCM-tutorial/) for
   comparative methods, including network calibration (2023 workshop)
 - the [google group](https://groups.google.com/g/juliaphylo-users)
   for common questions. Join the group to post/email your questions,

--- a/src/pseudolik.jl
+++ b/src/pseudolik.jl
@@ -417,24 +417,17 @@ function updateHasEdge!(qnet::QuartetNetwork, net::HybridNetwork)
                 else
                     ind1 = parse(Int,string(string(node.number),"1"))
                     ind2 = parse(Int,string(string(node.number),"2"))
-                    found1 = true
-                    found2 = true
-                    try
-                        getIndexEdge(ind1,qnet)
-                    catch
-                        found1 = false
-                    end
-                    try
-                        getIndexEdge(ind2,qnet)
-                    catch
-                        found2 = false
-                    end
+                    idx1 = findfirst(e -> e.number == ind1 && fromBadDiamondI(e),
+                                     qnet.edge)
+                    idx2 = findfirst(e -> e.number == ind2 && fromBadDiamondI(e),
+                                     qnet.edge)
+                    found1 = !isnothing(idx1)
+                    found2 = !isnothing(idx2)
                     if(!found1 && !found2)
                         push!(hz,false)
                         push!(hz,false)
                     elseif(found1 && !found2)
-                        index = getIndexEdge(ind1,qnet)
-                        if(!istIdentifiable(qnet.edge[index]) && all((n->!n.leaf), qnet.edge[index].node))
+                        if !istIdentifiable(qnet.edge[idx1]) && all((n->!n.leaf), qnet.edge[idx1].node)
                             push!(hz,true)
                         else
                             push!(hz,false)
@@ -442,16 +435,14 @@ function updateHasEdge!(qnet::QuartetNetwork, net::HybridNetwork)
                         push!(hz,false)
                     elseif(found2 && !found1)
                         push!(hz,false)
-                        index = getIndexEdge(ind2,qnet)
-                        if(!istIdentifiable(qnet.edge[index]) && all((n->!n.leaf), qnet.edge[index].node))
+                        if !istIdentifiable(qnet.edge[idx2]) && all((n->!n.leaf), qnet.edge[idx2].node)
                             push!(hz,true)
                         else
                             push!(hz,false)
                         end
                     else
-                        index1 = getIndexEdge(ind1,qnet)
-                        index2 = getIndexEdge(ind2,qnet)
-                        if(!istIdentifiable(qnet.edge[index1]) && all((n->!n.leaf), qnet.edge[index1].node) && !istIdentifiable(qnet.edge[index2]) && all((n->!n.leaf), qnet.edge[index2].node))
+                        if !istIdentifiable(qnet.edge[idx1]) && all((n->!n.leaf), qnet.edge[idx1].node) &&
+                           !istIdentifiable(qnet.edge[idx2]) && all((n->!n.leaf), qnet.edge[idx2].node)
                             error("strange qnet when net has node $(node.number) Bad Diamond I: qnet should have only one of the gammaz if it does not have node, but it has two")
                         end
                     end


### PR DESCRIPTION
Many thanks to @ericopolo for his diagnostic and proposed fix in #17 !

I did  not add a test to cover this case, because the example I have to reproduce it is small.
To reproduce, use [`tableCFs.txt`](https://github.com/crsl4/PhyloNetworks.jl/files/6145048/tableCFs.txt) and:
```julia
using CSV, DataFrames, PhyloNetworks, SNaQ
netstring = "((a,b):0.741,((((((c,(d)#H29:::0.893):0.039,(e,#H29:::0.107):0.039):1.682,((f,(g,#H25:0.0::0.331):0.519):0.591,((h,i):1.058,j):0.128):0.185):0.105,k):0.126,(((((l,(m)#H1:::0.897):0.714,(#H1:::0.103,((n,o):0.502,p):0.076):0.165):1.97,((q,((r,((s,t):0.499,(u)#H28:::0.765):0.199):0.134,(v,#H28:::0.235):0.437):1.889):0.0)#H30:0.308::0.976):0.247,#H30:0.0::0.024):0.367)#H25:0.003::0.669):1.142,(w,#H27:::0.273):0.25):0.24,(x)#H27:::0.727);"
qCF = CSV.read("tableCFs.txt", DataFrame);
net = readTopology(netstring)
topologyQpseudolik!(net, readtableCF(qCF)) # recalculate SNaQ score and all expected CFs
```
- tested on julia v1.12.7 and PhyloNetworks v1.4.0
- using the bug fix from this PR: no error. The output shows `between 49.0 and 838.0 gene trees per 4-taxon set` and returns `10455.54164712601`.
- using SNaQ v1.2.0 at PR #36 : we get the following error, similar to #17 (using earlier versions):
```
between 49.0 and 838.0 gene trees per 4-taxon set
ERROR: TaskFailedException

    nested task error: strange qnet when net has node 5 Bad Diamond I: qnet should have only one of the gammaz if it does not have node, but it has two
    Stacktrace:
     [1] error(s::String)
       @ Base ./error.jl:44
     [2] updateHasEdge!(qnet::SNaQ.QuartetNetwork, net::HybridNetwork)
       @ SNaQ ~/.julia/dev/SNaQ/src/pseudolik.jl:455
     ...
```